### PR TITLE
create unit tests for SoapMessageHandler class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,13 @@
 			<version>2.3.1</version>
 		</dependency>
 
+		<!-- Java API for XML-based Web Services (JAX-WS) SOAP API -->
+		<dependency>
+			<groupId>javax.xml.soap</groupId>
+			<artifactId>javax.xml.soap-api</artifactId>
+			<version>1.4.0</version>
+		</dependency>
+
 		<!-- Spring Boot Starter Test: Provides support for testing Spring Boot applications -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/test/java/com/sadramesbah/asynchronous_communicating_agents/handler/SoapMessageHandlerTest.java
+++ b/src/test/java/com/sadramesbah/asynchronous_communicating_agents/handler/SoapMessageHandlerTest.java
@@ -1,0 +1,131 @@
+package com.sadramesbah.asynchronous_communicating_agents.handler;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import javax.xml.bind.JAXBException;
+import jakarta.xml.soap.SOAPException;
+import jakarta.xml.soap.SOAPMessage;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SoapMessageHandlerTest {
+
+  private SoapMessageHandler soapMessageHandler;
+
+  @BeforeEach
+  void setUp() throws JAXBException, SOAPException {
+    soapMessageHandler = new SoapMessageHandler();
+  }
+
+  @Test
+  void testParseValidSoapMessage() throws SOAPException, IOException {
+    String soapMessageInString = new StringBuilder()
+        .append("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">")
+        .append("<soapenv:Header/>")
+        .append("<soapenv:Body>")
+        .append("<Message>")
+        .append("<MessageID>106</MessageID>")
+        .append("<MessageTitle>Test Title</MessageTitle>")
+        .append("<MessageBody>Test Body</MessageBody>")
+        .append("<CreationTime>2024-11-03T12:00:00Z</CreationTime>")
+        .append("<LastModified>2024-11-03T12:25:00Z</LastModified>")
+        .append("<LastAgent>Agent32</LastAgent>")
+        .append("<Status>Active</Status>")
+        .append("</Message>")
+        .append("</soapenv:Body>")
+        .append("</soapenv:Envelope>")
+        .toString();
+
+    SOAPMessage soapMessage = soapMessageHandler.parse(soapMessageInString);
+    assertNotNull(soapMessage);
+    assertNotNull(soapMessage.getSOAPBody());
+    assertNull(soapMessage.getSOAPBody().getFault());
+  }
+
+  @Test
+  void testParseInvalidSoapMessage() {
+    String soapMessageInString = new StringBuilder()
+        .append("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">")
+        .append("<soapenv:Header/>")
+        .append("<soapenv:Body>")
+        .append("<soapenv:Fault>")
+        .append("<faulttag>Invalid message</faulttag>")
+        .append("</soapenv:Fault>")
+        .append("</soapenv:Body>")
+        .append("</soapenv:Envelope>")
+        .toString();
+
+    assertThrows(SOAPException.class, () -> soapMessageHandler.parse(soapMessageInString));
+  }
+
+  @Test
+  void testToSoapString() throws SOAPException, IOException {
+    String soapMessageInString = new StringBuilder()
+        .append("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">")
+        .append("<soapenv:Header/>")
+        .append("<soapenv:Body>")
+        .append("<Message>")
+        .append("<MessageID>106</MessageID>")
+        .append("<MessageTitle>Test Title</MessageTitle>")
+        .append("<MessageBody>Test Body</MessageBody>")
+        .append("<CreationTime>2024-11-03T12:00:00Z</CreationTime>")
+        .append("<LastModified>2024-11-03T12:25:00Z</LastModified>")
+        .append("<LastAgent>Agent32</LastAgent>")
+        .append("<Status>Active</Status>")
+        .append("</Message>")
+        .append("</soapenv:Body>")
+        .append("</soapenv:Envelope>")
+        .toString();
+
+    SOAPMessage soapMessage = soapMessageHandler.parse(soapMessageInString);
+    String soapString = soapMessageHandler.toSoapString(soapMessage);
+    assertNotNull(soapString);
+    assertTrue(soapString.contains("<MessageID>106</MessageID>"));
+    assertTrue(soapString.contains("<MessageTitle>Test Title</MessageTitle>"));
+    assertTrue(soapString.contains("<MessageBody>Test Body</MessageBody>"));
+    assertTrue(soapString.contains("<CreationTime>2024-11-03T12:00:00Z</CreationTime>"));
+    assertTrue(soapString.contains("<LastModified>2024-11-03T12:25:00Z</LastModified>"));
+    assertTrue(soapString.contains("<LastAgent>Agent32</LastAgent>"));
+    assertTrue(soapString.contains("<Status>Active</Status>"));
+  }
+
+  @Test
+  void testParseSoapMessageWithMissingFields() {
+    String soapMessageInString = new StringBuilder()
+        .append("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">")
+        .append("<soapenv:Header/>")
+        .append("<soapenv:Body>")
+        .append("<Message>")
+        .append("<MessageID>106</MessageID>")
+        .append("<MessageTitle>Test Title</MessageTitle>")
+        .append("</Message>")
+        .append("</soapenv:Body>")
+        .append("</soapenv:Envelope>")
+        .toString();
+
+    assertThrows(SOAPException.class, () -> soapMessageHandler.parse(soapMessageInString));
+  }
+
+  @Test
+  void testParseEmptySoapMessage() {
+    String soapMessageInString = "";
+    assertThrows(SOAPException.class, () -> soapMessageHandler.parse(soapMessageInString));
+  }
+
+  @Test
+  void testParseSoapMessageWithFault() {
+    String soapMessageInString = new StringBuilder()
+        .append("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">")
+        .append("<soapenv:Header/>")
+        .append("<soapenv:Body>")
+        .append("<soapenv:Fault>")
+        .append("<faulttag>Invalid message</faulttag>")
+        .append("</soapenv:Fault>")
+        .append("</soapenv:Body>")
+        .append("</soapenv:Envelope>")
+        .toString();
+
+    assertThrows(SOAPException.class, () -> soapMessageHandler.parse(soapMessageInString));
+  }
+}


### PR DESCRIPTION
These tests are designed to evaluate the fundamental functionalities of the xmlMessageHandler class. Specifically, they assess the parsing of SOAP objects, the extraction of specific fields, and the creation of SOAP objects based on the available field values.