### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/java-ci-maven.yml
+++ b/.github/workflows/java-ci-maven.yml
@@ -12,6 +12,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/sadramesbah/asynchronous-communicating-agents/security/code-scanning/1](https://github.com/sadramesbah/asynchronous-communicating-agents/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (preferred here since there is only one job and no job-specific permission differences are shown). Set least privilege to:

- `contents: read`

This preserves current functionality (`actions/checkout` + Maven build) while ensuring `GITHUB_TOKEN` cannot unexpectedly gain broader access from external defaults.

**File to edit:** `.github/workflows/java-ci-maven.yml`  
**Region:** after the `on:` trigger block and before `jobs:` (or equivalently at top-level anywhere valid).  
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
